### PR TITLE
fix: use working guestfs-tools commit

### DIFF
--- a/Virtualization/kvm-qemu.sh
+++ b/Virtualization/kvm-qemu.sh
@@ -260,6 +260,7 @@ function install_libguestfs() {
     cd /opt || return
     if [ ! -d guestfs-tools ]; then
       git clone --recursive https://github.com/rwmjones/guestfs-tools.git
+      cd guestfs-tools
       git fetch --depth=1 origin ${LIBGUESTFS_TOOLS_GITHUB_SHA}
       git checkout ${LIBGUESTFS_TOOLS_GITHUB_SHA}
     fi

--- a/Virtualization/kvm-qemu.sh
+++ b/Virtualization/kvm-qemu.sh
@@ -263,6 +263,7 @@ function install_libguestfs() {
       cd guestfs-tools
       git fetch --depth=1 origin ${LIBGUESTFS_TOOLS_GITHUB_SHA}
       git checkout ${LIBGUESTFS_TOOLS_GITHUB_SHA}
+      cd ../
     fi
     cd guestfs-tools || return
     # Following tips to compile the guestfs-tools as depicted in https://www.mail-archive.com/libguestfs@redhat.com/msg22408.html

--- a/Virtualization/kvm-qemu.sh
+++ b/Virtualization/kvm-qemu.sh
@@ -260,6 +260,8 @@ function install_libguestfs() {
     cd /opt || return
     if [ ! -d guestfs-tools ]; then
       git clone --recursive https://github.com/rwmjones/guestfs-tools.git
+      git fetch --depth=1 origin ${LIBGUESTFS_TOOLS_GITHUB_SHA}
+      git checkout ${LIBGUESTFS_TOOLS_GITHUB_SHA}
     fi
     cd guestfs-tools || return
     # Following tips to compile the guestfs-tools as depicted in https://www.mail-archive.com/libguestfs@redhat.com/msg22408.html


### PR DESCRIPTION
It seems like there was an issue introduced in https://github.com/libguestfs/guestfs-tools Version 1.53.3.  This pr allows us to specify a commit like we do with libguestfs.  Using a hash from a couple weeks ago ([1.53.2](https://github.com/libguestfs/guestfs-tools/commit/daf2b71e0ef18a04928f82688278673ad57d4c4b)) fixed the build for me.